### PR TITLE
CI: автодеплой + фикс карусели стека + отступы на мобильных

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: pages-deploy
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Copy static files into dist
+        run: |
+          cp robots.txt dist/robots.txt
+          cp manifest.json dist/manifest.json
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: gh-pages


### PR DESCRIPTION
## Что внутри

**1. Автодеплой (`.github/workflows/deploy.yml`)**
PR #2 (редизайн) уже в `main`, но сайт `asewhy.github.io` всё ещё старый — Pages раздаётся из ветки `gh-pages`, а её обновляет только ручной `npm run publish`/`build-and-publish` с компьютера. Workflow при `push` в `main` (т.е. сразу при мердже этого PR) и по кнопке `workflow_dispatch`: `npm install` → `npm run build` → копирует `robots.txt`/`manifest.json` в `dist/` → публикует `dist/` в `gh-pages` через `peaceiris/actions-gh-pages`. Настройки Pages менять не нужно; ручной `npm run publish` тоже продолжит работать.

**2. Карусель «Языки и фреймворки»**
Старая карусель считала пиксельные сдвиги в JS на `setInterval` и «пинг-понгила» направление — выглядело криво и ломалось при ресайзе. Заменил на плавную CSS-марки: продублированная дорожка, бесконечная линейная анимация, пауза при наведении, контейнер с затуханием по краям и ограничением по ширине. JS-логика и хук `useSize` для неё больше не нужны.

**3. Отступы на мобильных**
Между секциями на телефоне было слишком много воздуха. Уменьшил `--space-section` (и `--space-7`) под 750px и убрал лишний `padding-top` высотой с шапку у блока «Обо мне».

## После мерджа

**Actions** → дождаться зелёного прогона «Deploy to GitHub Pages» (~1–2 мин) → сайт обновится (если кэшируется — открыть с `?v=2`). Дальше любой пуш в `main` деплоится сам.

https://claude.ai/code/session_01DUbsS9TjUPnaAbLQTnyczE